### PR TITLE
Fixing grid-span issue on mobile for index page

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,6 +4,7 @@ import { getApolloClient } from "../apollo-client";
 import { CardGrid, CardLink, PokemonCard } from "../components";
 import { DocumentHead } from "../models";
 import styles from "../styles/Page.module.css";
+import homeStyles from "../styles/Home.module.css";
 import { getRandomPokemonId } from "../utils";
 
 type Pokemon = {
@@ -92,7 +93,9 @@ const Home: NextPage<
           </p>
         </CardLink>
 
-        <PokemonCard {...pokemon} style={{ gridColumn: "span 2" }} />
+        <div className={homeStyles.featured_pokemon}>
+          <PokemonCard {...pokemon} />
+        </div>
       </CardGrid>
     </main>
   );

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -1,0 +1,5 @@
+@media (min-width: 600px) {
+  .featured_pokemon {
+    grid-column: span 2;
+  }
+}


### PR DESCRIPTION
This PR adds a media query to the `grid-column` property applied to the pokemon card component on the index page.